### PR TITLE
fix: remove functools from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ torchvision
 numpy
 pillow
 simpleeval
-functools
 PyYAML
 toml
+


### PR DESCRIPTION
The functools module is part of Python’s standard library and must not be listed in requirements.txt. The PyPI package with the same name is outdated, unmaintained, and fails to build on modern Python environments, breaking the installation process.

This PR removes the erroneous functools entry from requirements.txt to ensure smooth dependency installation.

✅ Changes:

Removed functools from requirements.txt
🔧 Testing:

Verified successful installation of dependencies in Python 3.10/3.11 Confirmed node functionality remains intact (no third-party functools was used) Note: Standard library usage (e.g., from functools import lru_cache) continues to work without any changes.